### PR TITLE
M1チップ用にMySQLイメージを修正

### DIFF
--- a/containers/db/Dockerfile
+++ b/containers/db/Dockerfile
@@ -1,1 +1,1 @@
-FROM mysql:8
+FROM --platform=linux/x86_64 mysql:8.0


### PR DESCRIPTION
# 概要
M1MacでMySQLイメージが使用できなかったので異なるイメージに変更